### PR TITLE
Fix use of `eliminate`

### DIFF
--- a/R/global.R
+++ b/R/global.R
@@ -113,8 +113,8 @@ global = function(from, to,  ids.to, moves = NULL, limit = 0, verbose = F){
   res = checkDVI(from = from, to = to,  ids.to = ids.to , moves = moves)
   ids.from = as.character(lapply(from, function(x) x$ID))
   marks = 1:nMarkers(from)
-  loglik0 = sum(likelihood(from, marker = marks, logbase = exp(1)), eliminate = 1) +
-            sum(likelihood(to,   marker = marks, logbase = exp(1)), eliminate = 1)
+  loglik0 = sum(likelihood(from, marker = marks, logbase = exp(1), eliminate = 1)) +
+            sum(likelihood(to,   marker = marks, logbase = exp(1), eliminate = 1))
   if(loglik0 == -Inf)
     stop("Impossible initial data")
   tomove = names(moves) #names of all victims up for a potential move
@@ -134,8 +134,8 @@ global = function(from, to,  ids.to, moves = NULL, limit = 0, verbose = F){
       from2 = relabel(from, thisMove[1,], names(thisMove))
       to2 = transferMarkers(from2, to, erase  = FALSE)
       from2 = setAlleles(from, ids = idFrom, alleles = 0)
-      loglik[i] = sum(likelihood(from2, marker = marks, logbase = exp(1)), eliminate = 1) +
-                  sum(likelihood(to2,   marker = marks, logbase = exp(1)), eliminate = 1)
+      loglik[i] = sum(likelihood(from2, marker = marks, logbase = exp(1), eliminate = 1)) +
+                  sum(likelihood(to2,   marker = marks, logbase = exp(1), eliminate = 1))
     }
   }
   LR = exp(loglik - loglik0)

--- a/R/marginal.R
+++ b/R/marginal.R
@@ -64,8 +64,8 @@ marginal = function(from, to, ids.to, moves, limit = 0.1,
   ids.from = as.character(lapply(from, function(x) x$ID))
   marks = 1:nMarkers(from)
   names(from) = ids.from
-  loglik0 = sum(likelihood(from, marker = marks, logbase = exp(1)), eliminate = 1) +
-            sum(likelihood(to,   marker = marks, logbase = exp(1)), eliminate = 1)
+  loglik0 = sum(likelihood(from, marker = marks, logbase = exp(1), eliminate = 1)) +
+            sum(likelihood(to,   marker = marks, logbase = exp(1), eliminate = 1))
   LR = list()
   if(loglik0 == -Inf)
     stop("Impossible initial data")
@@ -105,8 +105,8 @@ screen1 = function(from, to, ids.to, moves, loglik0, vict = 1, LRlimit = 0.1,
         from2 = relabel(from1, idTo, idFrom)
         am2 = transferMarkers(from2, to, idTo, erase = FALSE)
         pm2 =  setAlleles(from, ids = idFrom, alleles = 0)
-        logl[i] = sum(likelihood(pm2, marker = marks, logbase = exp(1)), eliminate = 1) +
-                  sum(likelihood(am2, marker = marks, logbase = exp(1)), eliminate = 1)
+        logl[i] = sum(likelihood(pm2, marker = marks, logbase = exp(1), eliminate = 1)) +
+                  sum(likelihood(am2, marker = marks, logbase = exp(1), eliminate = 1))
         LR[i] = exp(logl[i]-loglik0) 
         keep[i] = LR[i] > LRlimit
       }


### PR DESCRIPTION
Putting `eliminate = 1` inside the call to likelihood()