### PR TITLE
Speedup 2

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,3 @@
+loglikTotal = function(x, markers = seq_len(nMarkers(x))) {
+  sum(likelihood(x, marker = markers, logbase = exp(1), eliminate = 1))
+}


### PR DESCRIPTION
Two changes are suggested in this PR:

1) Outsource loglik computations to a separate function `loglikTotal()`, placed in "utils.R". This simplifies the code, and may fascilitate future improvements. 
At the moment, `loglikTotal()` contains the same code as before: `sum(likelihood(x, markers, logbase = exp(1), eliminate = 1))`. 

2) Avoid redundant computation of the PM logliks. These are now computed once, and re-used in the loops. As a result, `setAlleles()` could be skipped, giving a significant efficiency boost.