### PR TITLE
dviCompare tweaks

### DIFF
--- a/R/global.R
+++ b/R/global.R
@@ -113,6 +113,9 @@ global = function(from, to, ids.to, moves = NULL, limit = 0, numCores = 1, check
   
   st = Sys.time()
   
+  if(is.singleton(from))
+    from = list(from)
+  
   if(is.null(moves)) # Generate assignments
     moves = generateMoves(from = from, to = to, ids.to = ids.to, expand.grid = TRUE)
   else if(check)

--- a/R/sequential.R
+++ b/R/sequential.R
@@ -40,6 +40,10 @@
 #'
 #' @export
 sequential1 = function(pm, am, MPs, threshold = 1, check = TRUE, verbose = FALSE) {
+  
+  if(is.singleton(pm))
+    pm = list(pm)
+  
   # Victim labels
   vics = unlist(labels(pm))
   
@@ -82,6 +86,10 @@ sequential1 = function(pm, am, MPs, threshold = 1, check = TRUE, verbose = FALSE
 #' @rdname sequential1
 #' @export
 sequential2 = function(pm, am, MPs, threshold = 1, check = TRUE, verbose = FALSE) {
+  
+  if(is.singleton(pm))
+    pm = list(pm)
+  
   # Victim labels
   vics = unlist(labels(pm))
   
@@ -137,6 +145,10 @@ sequential2 = function(pm, am, MPs, threshold = 1, check = TRUE, verbose = FALSE
 #' @rdname sequential1
 #' @export
 sequential3 = function(pm, am, MPs, threshold = 10000, check = TRUE, verbose = FALSE, ...) {
+  
+  if(is.singleton(pm))
+    pm = list(pm)
+  
   # Victim labels
   vics = unlist(labels(pm))
   

--- a/man/dviCompare.Rd
+++ b/man/dviCompare.Rd
@@ -8,12 +8,13 @@ dviCompare(
   pm,
   am,
   MPs,
-  refs,
   true,
-  methods = 1:3,
+  refs = typedMembers(am),
+  methods = 1:4,
   markers = NULL,
+  threshold = 1,
   simulate = TRUE,
-  db = NULL,
+  db = getFreqDatabase(am),
   Nsim = 1,
   returnSims = FALSE,
   seed = NULL,
@@ -28,20 +29,24 @@ dviCompare(
 
 \item{MPs}{Character vector with names of the missing persons.}
 
-\item{refs}{Character vector with names of the reference individuals.}
-
 \item{true}{A character of the same length as `pm`, with the true solution,
 e.g., `true = c("MP2", "*", "MP3)` if the truth is V1 = MP2 and V3 = MP3.}
 
-\item{methods}{A subset of the numbers 1,2,3.}
+\item{refs}{Character vector with names of the reference individuals. By
+default the typed members of `am`.}
+
+\item{methods}{A subset of the numbers 1,2,3,4.}
 
 \item{markers}{If `simulate = FALSE`: A vector indicating which markers
 should be used.}
 
+\item{threshold}{An LR threshold passed on to the sequential methods.}
+
 \item{simulate}{A logical, indicating if simulations should be performed.}
 
 \item{db}{A frequency database used for simulation, e.g.,
-forrel::NorwegianFrequencies[1:10].}
+forrel::NorwegianFrequencies. By default the frequencies attached to `am`
+are used.}
 
 \item{Nsim}{A positive integer; the number of simulations.}
 
@@ -60,7 +65,7 @@ A list of solution frequencies for each method, and a vector of true
 }
 \description{
 The following methods are compared: 1 = sequential (simple); 2 = sequential
-(with updates); 3 = joint.
+(with updates); 3 = sequential + joint; 4 = joint.
 }
 \examples{
 
@@ -75,14 +80,14 @@ db = forrel::NorwegianFrequencies[1:10]
 true = c("MP1", "MP2", "MP3")
 
 # Run comparison
-dviCompare(pm, am, MPs, refs, true = true, 
+dviCompare(pm, am, MPs, refs, true = true,
            db = db, Nsim = 2, seed = 123)
 
 
 # Alternatively, simulations can be done first...
-sims = dviCompare(pm, am, MPs, refs, true = true, 
+sims = dviCompare(pm, am, MPs, refs, true = true,
                   db = db, Nsim = 2, seed = 123, returnSims = TRUE)
-                  
+
  # ... and computations after:
 dviCompare(sims$pm, sims$am, MPs, refs, true = true, simulate = FALSE)
 


### PR DESCRIPTION
A couple of minor improvements:

* If `pm` is a sole singleton, make it into a list
* Introduce default values in `dviCompare()`:
    * `refs = typedMembers(am)`
    * `db = getFreqDatabase(am)`

As a result, if `am` has attached markers, one can run e.g.,
``` r
dviCompare(pm, am, MPs, true, Nsim = 10)
```

<sup>Created on 2020-12-14 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

