### PR TITLE
Exclude impossible moves

### DIFF
--- a/R/expand.grid.nodup.R
+++ b/R/expand.grid.nodup.R
@@ -20,7 +20,10 @@
 #' 
 #' @export
 expand.grid.nodup = function(lst) {
-  stopifnot(is.list(lst))
+  if(is.data.frame(lst))
+    stop("Unexpected input: Argument `lst` is a data frame")
+  if(!is.list(lst))
+    stop("Argument `lst` should be a list")
   
   # Grid
   args = c(lst, list(KEEP.OUT.ATTRS = F, stringsAsFactors = F))

--- a/R/findUndisputed.R
+++ b/R/findUndisputed.R
@@ -25,7 +25,7 @@
 #' findUndisputed(pm, am, missing, threshold = 1e4)
 #'
 #' @export
-findUndisputed = function(pm, am, missing, threshold = 10000, check = TRUE, verbose = FALSE) {
+findUndisputed = function(pm, am, missing, threshold = 10000, limit = 0, check = TRUE, verbose = FALSE) {
   
   if(is.singleton(pm))
     pm = list(pm)

--- a/R/findUndisputed.R
+++ b/R/findUndisputed.R
@@ -1,23 +1,40 @@
 #' Undisputed identifications in DVI problems
 #'
 #' This function uses the single-search LR values to find "undisputed" matches
-#' between victims and missing individuals. An identification `V_i = M_j` is
-#' called undisputed if the corresponding likelihood ratio `LR_{i,j}` exceeds
-#' the given threshold, while all other values involving `v_i` or `M_j` are
-#' below 1.
+#' between victims and missing individuals. An identification \eqn{V_i = M_j} is
+#' called undisputed if the corresponding likelihood ratio \eqn{LR_{i,j}}
+#' exceeds the given threshold, while all other values involving \eqn{v_i} or
+#' \eqn{M_j} are below 1.
+#'
 #' @param pm PM data: List of singletons.
 #' @param am AM data: A `ped` object or list of such.
 #' @param missing Character vector with names of the missing persons.
-#' @param threshold A non-negative number. If no single-search LR values exceed this,
-#'   the iteration stops.
+#' @param threshold A non-negative number. If no single-search LR values exceed
+#'   this, the iteration stops.
+#' @param limit A positive number. Only single-search LR values above this are
+#'   considered.
 #' @param check A logical, indicating if the input data should be checked for
 #'   consistency.
 #' @param verbose A logical.
 #'
-#' @return A named character vector.
+#' @return A list with the following entries:
 #'
+#'   * `undisputed`: A list of undisputed matches and the corresponding LR
+#'   values.
+#'
+#'   * `pmReduced`: Same as `pm`, but with the undisputed victims removed.
+#'
+#'   * `amReduced`: Same as `am`, but with the data from undisputed victims
+#'   inserted.
+#'
+#'   * `missingReduced`: Same as `missing`, but without the undisputed
+#'   identified missing persons.
+#'
+#'   * `moves`, `LR.table`, `LRmatrix`: Output from `singleSearch()` applied to
+#'   the reduced problem.
+#'   
 #' @examples
-#' 
+#'
 #' pm = planecrash$pm
 #' am = planecrash$am
 #' missing = planecrash$missing
@@ -32,33 +49,23 @@ findUndisputed = function(pm, am, missing, threshold = 10000, limit = 0, check =
   
   # Victim labels
   vics = unlist(labels(pm))
+  names(pm) = vics  # ensure pm is named
   
-  # Store these for later
-  origPM = pm
-  origAM = am
-  origMissing = missing
-  origVics = vics
+  # Initialise output
+  RES = list()
   
-  # Initialise solution vector with no moves
-  RES = rep("*", length(pm))
-  names(RES) = vics
-  
-  # Ensure pm is named
-  names(pm) = vics
-  
-  ### Step 1: Sequential
-  if(verbose)
-    message("\nSequential identification of undisputed matches")
   it = 0
   
+  # single-search matrix
+  ss = singleSearch(pm, am, missing, check = check)
+  marg = ss$LR.table
+  
   # Loop until problem solved - or no more undisputed matches
-  while(length(missing) > 0 && length(vics) > 0) {
+  while(length(missing) > 0 && length(vics) > 0 && any(marg <= threshold)) {
     
-    # single-search matrix
-    marg = singleSearch(pm, am, missing, check = check)$LR.table
-    if(all(marg <= threshold))
-      break
-    
+    if(verbose)
+      message("\nIteration ", it <- it+1, ":")
+      
     # Indices of matches exceeding threshold
     highIdx = which(highLR <- marg > threshold, arr.ind = TRUE)
     
@@ -67,27 +74,27 @@ findUndisputed = function(pm, am, missing, threshold = 10000, limit = 0, check =
     goodCols = which(colSums(marg <= 1) == nrow(marg) - 1)
     isUndisp = highIdx[, "row"] %in% goodRows & highIdx[, "col"] %in% goodCols
     
-    if(!any(isUndisp)) 
+    if(!any(isUndisp)) {
+      if(verbose) message("No undisputed matches")
       break
+    }
     
     undisp = highIdx[isUndisp, , drop = FALSE]
     
-    if(verbose) {
-      message("\nIteration ", it <- it+1)
-      print(marg)
-      message("\nUndisputed matches in this iteration:")
-      for(i in seq_len(nrow(undisp))) {
-        rw = undisp[i,1]; cl = undisp[i,2]
-        message(sprintf(" %s = %s (LR = %.3g)", vics[rw], missing[cl], marg[rw,cl]))
-      }
+    for(i in seq_len(nrow(undisp))) {
+      rw = undisp[i,1]
+      cl = undisp[i,2]
+      vic = vics[rw] 
+      RES[[vic]] = list(match = missing[cl], LR = marg[rw,cl])
+      
+      if(verbose)
+        message(sprintf(" %s = %s (LR = %.3g)", vic, missing[cl], marg[rw,cl]))
     }
     
     undispVics = vics[undisp[, 1]]
     undispMP = missing[undisp[, 2]]
     
-    RES[undispVics] = undispMP
-    
-    ### Update the single-search LR matrix
+    ### Update the LR matrix
     
     # Move vic data to AM data
     am = transferMarkers(from = pm, to = am, idsFrom = undispVics, idsTo = undispMP, erase = FALSE)
@@ -98,7 +105,10 @@ findUndisputed = function(pm, am, missing, threshold = 10000, limit = 0, check =
     
     # Remove vic from pm
     pm = pm[vics]
+    
+    ss = singleSearch(pm, am, missing, check = FALSE)
+    marg = ss$LR.table
   }
   
-  RES[RES != "*"]
+  c(list(undisputed = RES, pmReduced = pm, amReduced = am, missingReduced = missing), ss)
 }

--- a/R/jointDVI.R
+++ b/R/jointDVI.R
@@ -122,13 +122,8 @@ jointDVI = function(pm, am, missing, moves = NULL, limit = 0, fixUndisputed = TR
   
   names(pm) = origVics = vics = unlist(labels(pm)) 
   
-  if(verbose) {
-    message("Input data:")
-    message(" Victims: ", toString(vics))
-    message(" Missing: ", toString(missing))
-    message(" Families: ", if(is.ped(am)) 1 else length(am))
-    message(" Refs: ", toString(typedMembers(am)))
-  }
+  if(verbose)
+    summariseDVI(pm, am, missing, printMax = 10)
   
   if(check)
     checkDVI(pm, am, missing, moves = moves)
@@ -294,3 +289,21 @@ checkDVI = function(pm, am, missing, moves){
 }
 
   
+summariseDVI = function(pm, am, missing, printMax = 10) {
+  vics = unlist(labels(pm))
+  refs = typedMembers(am)
+  
+  message("DVI problem:")
+  message(sprintf(" %d victims: %s", length(pm), trunc(vics, printMax)))
+  message(sprintf(" %d missing: %s", length(missing), trunc(missing, printMax)))
+  message(sprintf(" %d families", length(am)))
+  message(sprintf(" %d typed refs: %s", length(refs), trunc(refs, printMax)))
+}
+
+
+trunc = function(x, printMax) {
+  if(length(x) <= printMax)
+    return(toString(x))
+  y = c(x[1:5], "...", x[length(x)])
+  toString(y)
+}

--- a/R/jointDVI.R
+++ b/R/jointDVI.R
@@ -10,7 +10,8 @@
 #' @param missing Character vector with names of missing persons.
 #' @param moves List of length equal length of `pm` with possible individual
 #'   moves.
-#' @param limit Double. Only moves with LR above limit are kept.
+#' @param limit A positive number. Only single-search LR values above this are
+#'   considered.
 #' @param fixUndisputed A logical.
 #' @param threshold A positive number, passed onto [findUndisputed()].
 #' @param numCores Integer. The number of cores used in parallelisation.
@@ -230,10 +231,10 @@ jointDVI = function(pm, am, missing, moves = NULL, limit = 0, fixUndisputed = TR
   tab = cbind(moveGrid, loglik = loglik, LR = LR, posterior = posterior)
   
   # Remove matches with LR <= limit
-  keep = LR > limit
-  if(length(keep) == 0)
-    stop("No possible assignments. Try reducing limit")
-  tab = tab[keep, , drop = FALSE]
+  #keep = LR > limit
+  #if(length(keep) == 0)
+  #  stop("No possible assignments. Try reducing limit")
+  #tab = tab[keep, , drop = FALSE]
   
   # Sort in decreasing order
   tab = tab[order(tab$loglik, decreasing = TRUE), , drop = FALSE]

--- a/R/jointDVI.R
+++ b/R/jointDVI.R
@@ -120,8 +120,7 @@ jointDVI = function(pm, am, missing, moves = NULL, limit = 0, fixUndisputed = TR
   if(is.singleton(pm))
     pm = list(pm)
   
-  vics = unlist(labels(pm)) 
-  names(pm) = vics
+  names(pm) = origVics = vics = unlist(labels(pm)) 
   
   if(verbose) {
     message("Input data:")
@@ -134,52 +133,52 @@ jointDVI = function(pm, am, missing, moves = NULL, limit = 0, fixUndisputed = TR
   if(check)
     checkDVI(pm, am, missing, moves = moves)
   
-  if(fixUndisputed) {
-    undisp = findUndisputed(pm, am, missing, threshold = threshold, check = FALSE, verbose = verbose)
-    missing = setdiff(missing, undisp)
-    
-    # Remaining pm data
-    pmRem = pm[setdiff(vics, names(undisp))]
+  undisp = list()
   
-    # Generate all moves with the remaining victims
-    movesRem = generateMoves(pmRem, am, missing, expand.grid = FALSE)
+  if(fixUndisputed) {
     
-    # Add the undisputed and reorder
-    moves = c(movesRem, as.list(undisp))[vics]
+    if(verbose)
+      message("\nSequential identification of undisputed matches")
+    
+    r = findUndisputed(pm, am, missing, threshold = threshold, 
+                       limit = limit, check = FALSE, verbose = verbose)
+    
+    # List of undisputed, and their LR's
+    undisp = r$undisp 
+    
+    # Reduced DVI problem to be used in the joint analysis
+    pm = r$pmReduced
+    am = r$amReduced
+    missing = r$missingReduced
+    vics = names(pm)
+    
+    # Moves: These exclude those with LR = 0!
+    moves = r$moves
   }
     
-  if(is.null(moves)) # Generate assignments
-    moves = generateMoves(pm = pm, am = am, missing = missing, expand.grid = TRUE)
+  if(is.null(moves)) {
+    moves = singleSearch(pm, am, missing = missing)$moves
+  }
   
   # Expand if needed
-  moveGrid = if(is.data.frame(moves)) moves else expand.grid.nodup(moves)
+  moveGrid = expand.grid.nodup(moves)
   nMoves = nrow(moveGrid)
   if(nMoves == 0)
-    stop("No possible solutions specified, possibly identical moves")
+    stop("No possible solutions!")
+  if(verbose)
+    message("\nAssignments to consider in the joint analysis: ", nMoves, "\n")
   
-  # Convert to list, which is more handy below
+  # Convert to list; more handy below
   moveList = lapply(1:nMoves, function(i) as.character(moveGrid[i, ]))
-  
-  if(verbose) {
-    if(fixUndisputed) {
-      if(length(undisp) == 0) message("\nUndisputed: None\n")
-      else message("\nUndisputed:\n", sprintf(" %s = %s\n", names(undisp), undisp))
-    }
-    
-    message("Assignments to consider: ", nMoves)
-    message("")
-  }
   
   marks = seq_len(nMarkers(pm))
   
   # Initial loglikelihoods
   logliks.PM = vapply(pm, loglikTotal, markers = marks, FUN.VALUE = 1)
-  names(logliks.PM) = vics
   
   loglik0 = sum(logliks.PM) + loglikTotal(am, markers = marks)
   if(loglik0 == -Inf)
     stop("Impossible initial data")
-  
   
   # Function for computing the total log-likelihood after a given move
   singleMove = function(pm, am, vics, move, loglik0, logliks.PM) {
@@ -227,6 +226,18 @@ jointDVI = function(pm, am, missing, moves = NULL, limit = 0, fixUndisputed = TR
   LR = exp(loglik - loglik0)
   posterior = LR/sum(LR) # assumes a flat prior
   
+  # Add undisputed matches
+  if(length(undisp)) {
+    # Add ID columns
+    for(v in names(undisp)) moveGrid[[v]] = undisp[[v]]$match
+    
+    # Fix ordering
+    moveGrid = moveGrid[origVics]
+    
+    # Fix LR: Multiply with that of the undisputed
+    LR = LR * prod(sapply(undisp, `[[`, "LR"))
+  }
+    
   # Collect results
   tab = cbind(moveGrid, loglik = loglik, LR = LR, posterior = posterior)
   

--- a/R/singleSearch.R
+++ b/R/singleSearch.R
@@ -9,7 +9,8 @@
 #' @param am A list of pedigrees. The reference families.
 #' @param missing A character vector with names of missing persons.
 #' @param moves A list with possible assignments.
-#' @param limit A positive number, the lower threshold for LR.
+#' @param limit A positive number: only single-search LR values above this are
+#'   considered.
 #' @param nkeep An integer. No of moves to keep, all if `NULL`.
 #' @param check A logical, indicating if the input data should be checked for
 #'   consistency.
@@ -26,7 +27,7 @@
 #' singleSearch(pm, am, missing)
 #'
 #' @export
-singleSearch = function(pm, am, missing, moves = NULL, limit = 0.1, nkeep = NULL, 
+singleSearch = function(pm, am, missing, moves = NULL, limit = 0, nkeep = NULL, 
                     check = TRUE, verbose = FALSE){
   
   if(is.singleton(pm)) pm = list(pm)
@@ -109,7 +110,7 @@ singleSearch = function(pm, am, missing, moves = NULL, limit = 0.1, nkeep = NULL
   
   # Reduce moves according to `limit` and/or nkeep
   moves.reduced = lapply(LR.list, function(lrs) {
-    newmoves = names(lrs)[lrs >= limit]
+    newmoves = names(lrs)[lrs > limit]
     if(!is.null(nkeep) && length(newmoves) > nkeep)
       length(newmoves) = nkeep
     newmoves

--- a/R/singleSearch.R
+++ b/R/singleSearch.R
@@ -34,17 +34,17 @@ singleSearch = function(pm, am, missing, moves = NULL, limit = 0, nkeep = NULL,
   if(is.ped(am)) am = list(am)
   
   if(is.null(moves)) # Generate moves
-    moves = generateMoves(pm = pm, am = am, missing = missing)
+    moves = generateMoves(pm, am, missing = missing, expand.grid = FALSE)
   
   # Check consistency
   if(check)
-    checkDVI(pm = pm, am = am, missing = missing, moves = moves)
+    checkDVI(pm, am, missing = missing, moves = moves)
 
-  marks = 1:nMarkers(pm)
-  
   # Ensure correct names
   names(pm) = unlist(labels(pm), use.names = FALSE)
   vics = names(moves) # normally in the same order as names(pm)
+  
+  marks = 1:nMarkers(pm)
   
   # Loglik of each victim
   logliks.PM = vapply(pm, loglikTotal, markers = marks, FUN.VALUE = 1)

--- a/man/findUndisputed.Rd
+++ b/man/findUndisputed.Rd
@@ -33,14 +33,28 @@ consistency.}
 \item{verbose}{A logical.}
 }
 \value{
-A named character vector.
+A list with the following entries:
+
+  * `undisputed`: A list of undisputed matches and the corresponding LR
+  values.
+
+  * `pmReduced`: Same as `pm`, but with the undisputed victims removed.
+
+  * `amReduced`: Same as `am`, but with the data from undisputed victims
+  inserted.
+
+  * `missingReduced`: Same as `missing`, but without the undisputed
+  identified missing persons.
+
+  * `moves`, `LR.table`, `LRmatrix`: Output from `singleSearch()` applied to
+  the reduced problem.
 }
 \description{
 This function uses the single-search LR values to find "undisputed" matches
-between victims and missing individuals. An identification `V_i = M_j` is
-called undisputed if the corresponding likelihood ratio `LR_{i,j}` exceeds
-the given threshold, while all other values involving `v_i` or `M_j` are
-below 1.
+between victims and missing individuals. An identification \eqn{V_i = M_j} is
+called undisputed if the corresponding likelihood ratio \eqn{LR_{i,j}}
+exceeds the given threshold, while all other values involving \eqn{v_i} or
+\eqn{M_j} are below 1.
 }
 \examples{
 

--- a/man/findUndisputed.Rd
+++ b/man/findUndisputed.Rd
@@ -9,6 +9,7 @@ findUndisputed(
   am,
   missing,
   threshold = 10000,
+  limit = 0,
   check = TRUE,
   verbose = FALSE
 )
@@ -20,8 +21,11 @@ findUndisputed(
 
 \item{missing}{Character vector with names of the missing persons.}
 
-\item{threshold}{A non-negative number. If no single-search LR values exceed this,
-the iteration stops.}
+\item{threshold}{A non-negative number. If no single-search LR values exceed
+this, the iteration stops.}
+
+\item{limit}{A positive number. Only single-search LR values above this are
+considered.}
 
 \item{check}{A logical, indicating if the input data should be checked for
 consistency.}

--- a/man/jointDVI.Rd
+++ b/man/jointDVI.Rd
@@ -30,7 +30,8 @@ checkDVI(pm, am, missing, moves)
 \item{moves}{List of length equal length of `pm` with possible individual
 moves.}
 
-\item{limit}{Double. Only moves with LR above limit are kept.}
+\item{limit}{A positive number. Only single-search LR values above this are
+considered.}
 
 \item{fixUndisputed}{A logical.}
 

--- a/man/singleSearch.Rd
+++ b/man/singleSearch.Rd
@@ -9,7 +9,7 @@ singleSearch(
   am,
   missing,
   moves = NULL,
-  limit = 0.1,
+  limit = 0,
   nkeep = NULL,
   check = TRUE,
   verbose = FALSE
@@ -24,7 +24,8 @@ singleSearch(
 
 \item{moves}{A list with possible assignments.}
 
-\item{limit}{A positive number, the lower threshold for LR.}
+\item{limit}{A positive number: only single-search LR values above this are
+considered.}
 
 \item{nkeep}{An integer. No of moves to keep, all if `NULL`.}
 


### PR DESCRIPTION
This PR improves:

* the handling of "undisputed" identifications
* exclusions of single-moves with `LR <= limit`, with `limit = 0` by default. (In the previous version I completely overlooked the importance of this for reducing the search space.)

Here is a large example, which now runs in under 2 minutes with `jointDVI()`, with 4 cores:

``` r
library(dvir)

# Load large example
load("GHEPdvi.RData")
pm = GHEPdvi$pm 
am = GHEPdvi$am 
missing = GHEPdvi$MPs

# Families with mutations
bad = c(51, 70, 80)

# Joint analysis
r = jointDVI(pm, am[-bad], missing[-bad], verbose = T, numCores = 4)
#> DVI problem:
#>  76 victims: BS1m, BS2, BS3m, BS4, BS5, ..., BS85
#>  116 missing: MP1, MP2, MP3, MP4, MP5, ..., MP119
#>  116 families
#>  274 typed refs: RS1 [Brother], RS2 [Brother], RS3 [Brother], RS4 [Mother], RS5 [Father], ..., RS285 [Brother]
#> 
#> Sequential identification of undisputed matches
#> 
#> Iteration 1:
#>  BS27m = MP12 (LR = 1.47e+08)
#>  BS23 = MP31 (LR = 1.02e+05)
#>  BS45 = MP36 (LR = 2.43e+08)
#>  BS56 = MP44 (LR = 4.9e+08)
#>  BS62 = MP63 (LR = 1.57e+10)
#>  BS82 = MP72 (LR = 2.2e+13)
#>  BS77 = MP85 (LR = 3.37e+07)
#>  BS9 = MP90 (LR = 5.85e+08)
#>  BS12 = MP96 (LR = 4.1e+07)
#>  BS76 = MP110 (LR = 2.69e+21)
#>  BS49 = MP118 (LR = 2.51e+05)
#> 
#> Iteration 2:
#> No undisputed matches
#> 
#> Assignments to consider in the joint analysis: 35
#> Using 4 cores
#> Time used: 1.74 mins
```
