### PR TITLE
Faster `expand.grid.nodup()`

### DIFF
--- a/R/expand.grid.nodup.R
+++ b/R/expand.grid.nodup.R
@@ -25,6 +25,51 @@ expand.grid.nodup = function(lst) {
   if(!is.list(lst))
     stop("Argument `lst` should be a list")
   
+  len = length(lst)  
+  if(len == 0)
+    return(data.frame())
+  
+  nms = names(lst)
+  if(is.null(nms)) 
+    nms = paste0("Var", 1:len)
+  
+  # If empty: Return early
+  if(any(lengths(lst) == 0))
+    return(data.frame(matrix(nrow = 0, ncol = len), dimnames = list(NULL, nms)))
+  
+  # Recursive function
+  recurse = function(a) {
+    if(length(a) == 1)
+      return(as.list.default(a[[1]]))
+    
+    r = lapply(a[[1]], function(val) {
+      b = a[-1]
+      if(val != "*")
+        b = lapply(b, function(vec) vec[vec != val])
+      lapply(recurse(b), function(vec) c(val, vec))
+    })
+    
+    unlist(r, recursive = FALSE)
+  }
+  
+  # Call it!
+  reslist = recurse(lst)
+  
+  # Convert to data frame and add names
+  res = as.data.frame.matrix(do.call(rbind, reslist))
+  names(res) = nms
+  
+  res
+}
+
+
+# Old version wrapping expand.grid, chokes on large input
+expand.grid.nodup.OLD = function(lst) {
+  if(is.data.frame(lst))
+    stop("Unexpected input: Argument `lst` is a data frame")
+  if(!is.list(lst))
+    stop("Argument `lst` should be a list")
+  
   # Grid
   args = c(lst, list(KEEP.OUT.ATTRS = F, stringsAsFactors = F))
   full.grid = do.call(expand.grid, args)


### PR DESCRIPTION
Complete rewrite avoiding `expand.grid()` entirely (since this blows up in already in medium-sized examples).

The new version is recursive, and will probably also run into problems in extreme cases. But at least the problems showed in Issue #21 are now resolved:

``` r
library(dvir)

toyExample = function(n) rep(list(c("*", "M")), n)

toyExample(3)
#> [[1]]
#> [1] "*" "M"
#> 
#> [[2]]
#> [1] "*" "M"
#> 
#> [[3]]
#> [1] "*" "M"

# Note slightly different ordering
expand.grid.nodup(toyExample(3))
#>   Var1 Var2 Var3
#> 1    *    *    *
#> 2    *    *    M
#> 3    *    M    *
#> 4    M    *    *

# Big example now runs quickly
system.time(expand.grid.nodup(toyExample(100)))
#>    user  system elapsed 
#>    0.06    0.00    0.07
```

<sup>Created on 2020-12-18 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
