### PR TITLE
Respect `moves`

### DIFF
--- a/R/Bmarginal.R
+++ b/R/Bmarginal.R
@@ -1,19 +1,20 @@
 #' Marginal Bayesian identification probabilities
 #'
-#' Based on a prior and  the output from [jointDVI()], the posterior identification 
-#' probabilities are found.
+#' Based on a prior and  the output from [jointDVI()], the posterior
+#' identification probabilities are found.
+#'
+#' The prior assigns a probability to each assignment, each row of `jointRes`.
+#' If the prior is not specified, a flat prior is used. The prior need not sum
+#' to 1 since the user may rather choose a flat prior on the `apriori` possible
+#' assignments.
 #'
 #' @param jointRes Output from [jointDVI()].
 #' @param missing Character vector with names of missing persons.
-#' @param prior A numeric vector of length equal the number of rows on `jointRes`. 
-#' Default is a flat prior.
+#' @param prior A numeric vector of length equal the number of rows on
+#'   `jointRes`. Default is a flat prior.
 #'
-#' @return A matrix. Row i gives the posterior probability that victim i is 
-#' one of the missimg persons or someone else, denoted '*'.
-#' 
-#' @details The prior assigns a probability to each assignment, each row of `jointRes`. 
-#' If the prior is not specified, a flat prior is used. The prior need not sum to 1 since the user may
-#' rather choose a flat prior on the `apriori` possible assignments. 
+#' @return A matrix. Row `i` gives the posterior probability that victim `i` is
+#'   one of the missimg persons or someone else, denoted '*'.
 #'
 #' @seealso [jointDVI()]
 #'
@@ -23,42 +24,49 @@
 #' am = example1$am
 #' missing = example1$missing
 #' jointRes = jointDVI(pm, am, missing)
-#' Bmarginal(jointRes,  missing)
+#'
+#' Bmarginal(jointRes, missing)
+#'
 #' # Artificial example, all but optimal solution excluded by prior:
-#' Bmarginal(jointRes,  missing, prior = c(1, rep(0,26)))
-#' 
+#' Bmarginal(jointRes, missing, prior = c(1, rep(0,26)))
+#'
 #' # Another example:
 #' data(planecrash)
 #' pm = planecrash$pm
 #' am = planecrash$am
 #' missing = planecrash$missing
 #' jointRes = jointDVI(pm, am, missing)
-#' Bmarginal(jointRes,  missing)
-#' 
+#' Bmarginal(jointRes, missing)
 #'
 #'
 #' @export
-Bmarginal = function(jointRes,  missing, prior = NULL){
-  # Deal with prior
+Bmarginal = function(jointRes, missing, prior = NULL){
+  
   d = dim(jointRes)
+  
+  # Deal with prior
   if(is.null(prior))
     prior = rep(1/d[1], d[1])  
   else if(length(prior) != d[1])
     stop("Length of prior should equal number of rows in first argument")
+  
   # Find names of victims
-  nv = (1:d[2])[names(jointRes)=="loglik"]-1
+  nv = (1:d[2])[names(jointRes) == "loglik"] - 1
   victims = names(jointRes)[1:nv]
+  
   # Initialise result table 
   val = c(missing, '*')
   res = matrix(nrow = nv, ncol = length(val), 0)
   dimnames(res) = list(victims, val)
+  
   # Find denominator, const, and do calculations
-  x = data.frame(jointRes, term = prior*exp(jointRes$loglik))
+  x = data.frame(jointRes, term = prior * exp(jointRes$loglik))
   const = sum(x$term)  
   for(v in 1:nv){
     r1 = split(x$term, x[,v])
     p = sapply(r1,sum)/const
     res[v, names(p)] = p
   }
+  
   res
 }

--- a/R/findUndisputed.R
+++ b/R/findUndisputed.R
@@ -9,6 +9,8 @@
 #' @param pm PM data: List of singletons.
 #' @param am AM data: A `ped` object or list of such.
 #' @param missing Character vector with names of the missing persons.
+#' @param moves A list of possible assignments for each victim. If NULL, all
+#'   sex-matching assignments are considered.
 #' @param threshold A non-negative number. If no single-search LR values exceed
 #'   this, the iteration stops.
 #' @param limit A positive number. Only single-search LR values above this are
@@ -32,7 +34,7 @@
 #'
 #'   * `moves`, `LR.table`, `LRmatrix`: Output from `singleSearch()` applied to
 #'   the reduced problem.
-#'   
+#'
 #' @examples
 #'
 #' pm = planecrash$pm
@@ -42,7 +44,7 @@
 #' findUndisputed(pm, am, missing, threshold = 1e4)
 #'
 #' @export
-findUndisputed = function(pm, am, missing, threshold = 10000, limit = 0, check = TRUE, verbose = FALSE) {
+findUndisputed = function(pm, am, missing, moves = NULL, threshold = 10000, limit = 0, check = TRUE, verbose = FALSE) {
   
   if(is.singleton(pm))
     pm = list(pm)
@@ -57,7 +59,7 @@ findUndisputed = function(pm, am, missing, threshold = 10000, limit = 0, check =
   it = 0
   
   # single-search matrix
-  ss = singleSearch(pm, am, missing, check = check)
+  ss = singleSearch(pm, am, missing, moves = moves, check = check)
   marg = ss$LR.table
   
   # Loop until problem solved - or no more undisputed matches
@@ -106,7 +108,11 @@ findUndisputed = function(pm, am, missing, threshold = 10000, limit = 0, check =
     # Remove vic from pm
     pm = pm[vics]
     
-    ss = singleSearch(pm, am, missing, check = FALSE)
+    # Update `moves`, if given
+    if(!is.null(moves))
+      moves = lapply(moves[vics], function(v) setdiff(v, undispMP))
+    
+    ss = singleSearch(pm, am, missing, moves = moves, check = FALSE)
     marg = ss$LR.table
   }
   

--- a/R/jointDVI.R
+++ b/R/jointDVI.R
@@ -8,8 +8,8 @@
 #' @param pm A list of singletons.
 #' @param am A list of pedigrees.
 #' @param missing Character vector with names of missing persons.
-#' @param moves List of length equal length of `pm` with possible individual
-#'   moves.
+#' @param moves A list of possible assignments for each victim. If NULL, all
+#'   sex-matching assignments are considered.
 #' @param limit A positive number. Only single-search LR values above this are
 #'   considered.
 #' @param markers A vector indicating which markers should be included in the
@@ -176,7 +176,7 @@ jointDVI = function(pm, am, missing, moves = NULL, limit = 0, fixUndisputed = TR
       message(" Single-search LR threshold = ", threshold)
     }
     
-    r = findUndisputed(pm, am, missing, threshold = threshold, 
+    r = findUndisputed(pm, am, missing, moves = moves, threshold = threshold, 
                        limit = limit, check = FALSE, verbose = verbose)
     
     # List of undisputed, and their LR's
@@ -193,7 +193,7 @@ jointDVI = function(pm, am, missing, moves = NULL, limit = 0, fixUndisputed = TR
   }
     
   if(is.null(moves)) {
-    moves = singleSearch(pm, am, missing = missing, limit = limit)$moves
+    moves = singleSearch(pm, am, missing = missing, moves = moves, limit = limit)$moves
   }
  
   # Expand moves to grid

--- a/R/singleSearch.R
+++ b/R/singleSearch.R
@@ -8,7 +8,8 @@
 #' @param pm A list of singletons, the victims.
 #' @param am A list of pedigrees. The reference families.
 #' @param missing A character vector with names of missing persons.
-#' @param moves A list with possible assignments.
+#' @param moves A list of possible assignments for each victim. If NULL, all
+#'   sex-matching assignments are considered.
 #' @param limit A positive number: only single-search LR values above this are
 #'   considered.
 #' @param nkeep An integer. No of moves to keep, all if `NULL`.

--- a/man/Bmarginal.Rd
+++ b/man/Bmarginal.Rd
@@ -11,21 +11,22 @@ Bmarginal(jointRes, missing, prior = NULL)
 
 \item{missing}{Character vector with names of missing persons.}
 
-\item{prior}{A numeric vector of length equal the number of rows on `jointRes`. 
-Default is a flat prior.}
+\item{prior}{A numeric vector of length equal the number of rows on
+`jointRes`. Default is a flat prior.}
 }
 \value{
-A matrix. Row i gives the posterior probability that victim i is 
-one of the missimg persons or someone else, denoted '*'.
+A matrix. Row `i` gives the posterior probability that victim `i` is
+  one of the missimg persons or someone else, denoted '*'.
 }
 \description{
-Based on a prior and  the output from [jointDVI()], the posterior identification 
-probabilities are found.
+Based on a prior and  the output from [jointDVI()], the posterior
+identification probabilities are found.
 }
 \details{
-The prior assigns a probability to each assignment, each row of `jointRes`. 
-If the prior is not specified, a flat prior is used. The prior need not sum to 1 since the user may
-rather choose a flat prior on the `apriori` possible assignments.
+The prior assigns a probability to each assignment, each row of `jointRes`.
+If the prior is not specified, a flat prior is used. The prior need not sum
+to 1 since the user may rather choose a flat prior on the `apriori` possible
+assignments.
 }
 \examples{
 data(example1)
@@ -33,9 +34,11 @@ pm = example1$pm
 am = example1$am
 missing = example1$missing
 jointRes = jointDVI(pm, am, missing)
-Bmarginal(jointRes,  missing)
+
+Bmarginal(jointRes, missing)
+
 # Artificial example, all but optimal solution excluded by prior:
-Bmarginal(jointRes,  missing, prior = c(1, rep(0,26)))
+Bmarginal(jointRes, missing, prior = c(1, rep(0,26)))
 
 # Another example:
 data(planecrash)
@@ -43,8 +46,7 @@ pm = planecrash$pm
 am = planecrash$am
 missing = planecrash$missing
 jointRes = jointDVI(pm, am, missing)
-Bmarginal(jointRes,  missing)
-
+Bmarginal(jointRes, missing)
 
 
 }

--- a/man/findUndisputed.Rd
+++ b/man/findUndisputed.Rd
@@ -8,6 +8,7 @@ findUndisputed(
   pm,
   am,
   missing,
+  moves = NULL,
   threshold = 10000,
   limit = 0,
   check = TRUE,
@@ -20,6 +21,9 @@ findUndisputed(
 \item{am}{AM data: A `ped` object or list of such.}
 
 \item{missing}{Character vector with names of the missing persons.}
+
+\item{moves}{A list of possible assignments for each victim. If NULL, all
+sex-matching assignments are considered.}
 
 \item{threshold}{A non-negative number. If no single-search LR values exceed
 this, the iteration stops.}

--- a/man/jointDVI.Rd
+++ b/man/jointDVI.Rd
@@ -29,8 +29,8 @@ checkDVI(pm, am, missing, moves)
 
 \item{missing}{Character vector with names of missing persons.}
 
-\item{moves}{List of length equal length of `pm` with possible individual
-moves.}
+\item{moves}{A list of possible assignments for each victim. If NULL, all
+sex-matching assignments are considered.}
 
 \item{limit}{A positive number. Only single-search LR values above this are
 considered.}

--- a/man/singleSearch.Rd
+++ b/man/singleSearch.Rd
@@ -22,7 +22,8 @@ singleSearch(
 
 \item{missing}{A character vector with names of missing persons.}
 
-\item{moves}{A list with possible assignments.}
+\item{moves}{A list of possible assignments for each victim. If NULL, all
+sex-matching assignments are considered.}
 
 \item{limit}{A positive number: only single-search LR values above this are
 considered.}


### PR DESCRIPTION
This PR (hopefully) fixes the treatment of `moves`, which fell out when `findUndisputed()` waas implemented.

Also some quick code styling of `Bmarginal()`