### PR TITLE
Fix bug in `sequentialDVI()`

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -148,6 +148,8 @@
 #'   * `missing`: A vector containing the names of the 20 missing persons.
 #'   
 #' @examples 
+#' library(pedtools)
+#' 
 #' pm = sibPairs$pm
 #' am = sibPairs$am
 #' missing = sibPairs$missing

--- a/R/data.R
+++ b/R/data.R
@@ -151,6 +151,7 @@
 #' pm = sibPairs$pm
 #' am = sibPairs$am
 #' missing = sibPairs$missing
+#' 
 #' # All correctly identified using all 35 markers:
 #' sequentialDVI(pm, am, missing, updateLR = FALSE)
 #' 
@@ -161,6 +162,9 @@
 #' am15 = selectMarkers(am, markers = set1)        
 #' sequentialDVI(pm15, am15, missing, updateLR = FALSE)
 #' 
+#' # But all are identified if the LR matrix is updated in each step
+#' sequentialDVI(pm, am, missing, updateLR = TRUE)
+#' 
 #' # All correctly identified using 23 markers:
 #' set2 = c("D1S1656", "D2S441", "D10S1248", "D12S391", "D22S1045", "PENTA_D", "PENTA_E", "SE33")
 #' pm23 = selectMarkers(pm, markers = c(set1, set2))
@@ -169,15 +173,11 @@
 #' 
 #' # I did not wait for below to possibly finish since
 #' # 'Assignments to consider in the joint analysis: 2390116
-#' res3 = jointDVI(pm, am, missing, verbose = TRUE)
+#' # res3 = jointDVI(pm, am, missing, verbose = TRUE)
 #' 
 #' # Works nicely with reduced threshold
 #' res3 = jointDVI(pm, am, missing, verbose = TRUE, threshold = 100)
 #' 
-#' \dontrun{
-#' # Error:
-#' sequentialDVI(pm, am, missing, updateLR = TRUE, check = FALSE)
-#' }
 #' 
 "sibPairs"
 

--- a/R/jointDVI.R
+++ b/R/jointDVI.R
@@ -74,7 +74,7 @@ jointDVI = function(pm, am, missing, moves = NULL, limit = 0, undisputed = TRUE,
   }
   
   if(verbose)
-    summariseDVI(pm, am, missing, printMax = 10)
+    summariseDVI(pm, am, missing, method = "Joint identification", printMax = 10)
   
   if(check)
     checkDVI(pm, am, missing, moves = moves)
@@ -294,7 +294,7 @@ checkDVI = function(pm, am, missing, moves, errorIfEmpty = FALSE){
 }
 
   
-summariseDVI = function(pm, am, missing, printMax = 10) {
+summariseDVI = function(pm, am, missing, method = NULL, printMax = 10) {
   vics = unlist(labels(pm))
   refs = typedMembers(am)
   
@@ -303,6 +303,8 @@ summariseDVI = function(pm, am, missing, printMax = 10) {
   message(sprintf(" %d missing: %s", length(missing), trunc(missing, printMax)))
   message(sprintf(" %d families", length(am)))
   message(sprintf(" %d typed refs: %s", length(refs), trunc(refs, printMax)))
+  if(!is.null(method))
+    message(method)
 }
 
 

--- a/R/sequentialDVI.R
+++ b/R/sequentialDVI.R
@@ -23,10 +23,15 @@
 #'
 #' @export
 sequentialDVI = function(pm, am, missing, updateLR = TRUE, 
-                         threshold = 1, check = TRUE, verbose = FALSE) {
+                         threshold = 1, check = TRUE, verbose = TRUE, debug = FALSE) {
   
   if(is.singleton(pm))
     pm = list(pm)
+  
+  if(verbose) {
+    method = sprintf("Sequential search %s LR updates", ifelse(updateLR, "with", "without"))
+    summariseDVI(pm, am, missing, printMax = 10, method = method)
+  }
   
   # Victim labels
   names(pm) = vics = unlist(labels(pm)) 
@@ -58,13 +63,14 @@ sequentialDVI = function(pm, am, missing, updateLR = TRUE,
     RES[vic] = mp
     
     if(verbose) {
-      cat("Iteration", i<-i+1, "\n")
-      print(marg)
-      message(sprintf("--> %s = %s", vic, mp))
+      message("\nIteration ", i<-i+1)
+      if(debug) print(marg)
+      message(sprintf("---> %s = %s (LR = %.2g)", vic, mp, max(marg)))
     }
     
     if(i == length(RES)) 
       break 
+    
     ### Update the LR matrix
     
     if(updateLR) {

--- a/R/sequentialDVI.R
+++ b/R/sequentialDVI.R
@@ -29,7 +29,7 @@ sequentialDVI = function(pm, am, missing, updateLR = TRUE,
     pm = list(pm)
   
   # Victim labels
-  vics = unlist(labels(pm))
+  names(pm) = vics = unlist(labels(pm)) 
   
   # Initialise solution vector with no moves
   RES = rep("*", length(pm))

--- a/R/sequentialDVI.R
+++ b/R/sequentialDVI.R
@@ -10,6 +10,8 @@
 #' @param check A logical, indicating if the input data should be checked for
 #'   consistency.
 #' @param verbose A logical.
+#' @param debug A logical. If TRUE, the LR matrix is printed 
+#' 
 #'
 #' @return A solution to the DVI problem in the form of an assignment vector.
 #'

--- a/man/sequentialDVI.Rd
+++ b/man/sequentialDVI.Rd
@@ -32,6 +32,8 @@ this, the iteration stops.}
 consistency.}
 
 \item{verbose}{A logical.}
+
+\item{debug}{A logical. If TRUE, the LR matrix is printed}
 }
 \value{
 A solution to the DVI problem in the form of an assignment vector.

--- a/man/sequentialDVI.Rd
+++ b/man/sequentialDVI.Rd
@@ -11,7 +11,8 @@ sequentialDVI(
   updateLR = TRUE,
   threshold = 1,
   check = TRUE,
-  verbose = FALSE
+  verbose = TRUE,
+  debug = FALSE
 )
 }
 \arguments{

--- a/man/sibPairs.Rd
+++ b/man/sibPairs.Rd
@@ -28,6 +28,7 @@ Vi = Mi, i = 1, ..., 20.
 pm = sibPairs$pm
 am = sibPairs$am
 missing = sibPairs$missing
+
 # All correctly identified using all 35 markers:
 sequentialDVI(pm, am, missing, updateLR = FALSE)
 
@@ -38,6 +39,9 @@ pm15 = selectMarkers(pm, markers = set1)
 am15 = selectMarkers(am, markers = set1)        
 sequentialDVI(pm15, am15, missing, updateLR = FALSE)
 
+# But all are identified if the LR matrix is updated in each step
+sequentialDVI(pm, am, missing, updateLR = TRUE)
+
 # All correctly identified using 23 markers:
 set2 = c("D1S1656", "D2S441", "D10S1248", "D12S391", "D22S1045", "PENTA_D", "PENTA_E", "SE33")
 pm23 = selectMarkers(pm, markers = c(set1, set2))
@@ -46,15 +50,11 @@ sequentialDVI(pm23, am23, missing, updateLR = FALSE)
 
 # I did not wait for below to possibly finish since
 # 'Assignments to consider in the joint analysis: 2390116
-res3 = jointDVI(pm, am, missing, verbose = TRUE)
+# res3 = jointDVI(pm, am, missing, verbose = TRUE)
 
 # Works nicely with reduced threshold
 res3 = jointDVI(pm, am, missing, verbose = TRUE, threshold = 100)
 
-\dontrun{
-# Error:
-sequentialDVI(pm, am, missing, updateLR = TRUE, check = FALSE)
-}
 
 }
 \keyword{datasets}

--- a/man/sibPairs.Rd
+++ b/man/sibPairs.Rd
@@ -25,6 +25,8 @@ and a missing grandson and a missing granddaughter. The data is simulated accord
 Vi = Mi, i = 1, ..., 20.
 }
 \examples{
+library(pedtools)
+
 pm = sibPairs$pm
 am = sibPairs$am
 missing = sibPairs$missing


### PR DESCRIPTION
Also improves verbose output in some places.

The previously skipped `sibPairs` example now runs ok.