### PR TITLE
New parameter `numCores` in `pairwiseLR()` allowing parallelisation

### DIFF
--- a/R/findUndisputed.R
+++ b/R/findUndisputed.R
@@ -22,6 +22,8 @@
 #'   considered.
 #' @param check A logical indicating if the input data should be checked for
 #'   consistency. Default: TRUE.
+#' @param numCores An integer; the number of cores used in parallelisation.
+#'   Default: 1.
 #' @param verbose A logical. Default: TRUE.
 #'
 #' @seealso [pairwiseLR()]
@@ -49,7 +51,7 @@
 #'
 #' @export
 findUndisputed = function(dvi, pairings = NULL, ignoreSex = FALSE, threshold = 10000, 
-                          relax = FALSE, limit = 0, check = TRUE, verbose = TRUE) {
+                          relax = FALSE, limit = 0, check = TRUE, numCores = 1, verbose = TRUE) {
   
   if(verbose) {
     message("\nFinding undisputed matches")
@@ -73,7 +75,8 @@ findUndisputed = function(dvi, pairings = NULL, ignoreSex = FALSE, threshold = 1
     missing = dvi$missing
     
     # Pairwise LR matrix
-    ss = pairwiseLR(dvi, pairings = pairings, ignoreSex = ignoreSex, check = check, limit = limit, verbose = verbose)
+    ss = pairwiseLR(dvi, pairings = pairings, ignoreSex = ignoreSex, check = check, limit = limit, 
+                    numCores = numCores, verbose = verbose)
     B = ss$LRmatrix
     
     # Indices of matches exceeding threshold

--- a/man/findUndisputed.Rd
+++ b/man/findUndisputed.Rd
@@ -12,6 +12,7 @@ findUndisputed(
   relax = FALSE,
   limit = 0,
   check = TRUE,
+  numCores = 1,
   verbose = TRUE
 )
 }
@@ -34,6 +35,9 @@ considered.}
 
 \item{check}{A logical indicating if the input data should be checked for
 consistency. Default: TRUE.}
+
+\item{numCores}{An integer; the number of cores used in parallelisation.
+Default: 1.}
 
 \item{verbose}{A logical. Default: TRUE.}
 }

--- a/man/jointDVI.Rd
+++ b/man/jointDVI.Rd
@@ -53,7 +53,7 @@ disable mutations in all reference families without Mendelian errors.}
 the joint calculation exceeds this, the function will abort with an
 informative error message. Default: 1e5.}
 
-\item{numCores}{Integer. The number of cores used in parallelisation.
+\item{numCores}{An integer; the number of cores used in parallelisation.
 Default: 1.}
 
 \item{check}{A logical, indicating if the input data should be checked for

--- a/man/pairwiseLR.Rd
+++ b/man/pairwiseLR.Rd
@@ -11,6 +11,7 @@ pairwiseLR(
   limit = 0,
   nkeep = NULL,
   check = TRUE,
+  numCores = 1,
   verbose = FALSE
 )
 }
@@ -26,10 +27,14 @@ sex-consistent pairings are used.}
 output: Only pairings with LR greater or equal to \code{limit} are kept. If zero
 (default), pairings with LR > 0 are kept.}
 
-\item{nkeep}{An integer. No of pairings to keep, all if \code{NULL}.}
+\item{nkeep}{An integer, or NULL. If given, only the \code{nkeep} most likely
+pairings are kept for each victim.}
 
 \item{check}{A logical, indicating if the input data should be checked for
 consistency.}
+
+\item{numCores}{An integer; the number of cores used in parallelisation.
+Default: 1.}
 
 \item{verbose}{A logical.}
 }


### PR DESCRIPTION
Also pass `numCores` between functions when appropriate.