### PR TITLE
Allow empty DVI (and fix ordering bug)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Encoding: UTF-8
 Language: en-GB
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 Suggests: 
     knitr,
     rmarkdown

--- a/R/dviData.R
+++ b/R/dviData.R
@@ -145,7 +145,9 @@ subsetDVI = function(dvi, pm = NULL, am = NULL, missing = NULL, verbose = TRUE) 
     if(is.null(missing)) {
       comps = getComponent(amNew, dvi$missing, checkUnique = FALSE, errorIfUnknown = FALSE)
       if(anyNA(comps)) {
-        message("Removing missing persons in dropped AM families:\n ", toString(dvi$missing[!is.na(comps)]))
+        if(verbose)
+          message("Removing missing persons in dropped AM families:\n ", 
+                  toString(dvi$missing[!is.na(comps)]))
         missNew = dvi$missing[!is.na(comps)]
       }
     }
@@ -171,7 +173,8 @@ subsetDVI = function(dvi, pm = NULL, am = NULL, missing = NULL, verbose = TRUE) 
       
       unused = setdiff(seq_along(dvi$am), comps)
       if(length(unused)) {
-        message("Removing AM families with no missing persons: ", toString(unused))
+        if(verbose)
+          message("Removing AM families with no missing persons: ", toString(unused))
         amNew[unused] = NULL
       }
     }

--- a/R/dviData.R
+++ b/R/dviData.R
@@ -15,14 +15,14 @@ dviData = function(pm, am, missing) {
   if(inherits(pm, "dviData"))
     return(pm)
   
-  if(!length(missing))
-    stop2("The dataset has no missing persons")
+  #if(!length(missing))
+  #  stop2("The dataset has no missing persons")
   
-  if(!length(pm))
-    stop2("Empty PM data")
+  #if(!length(pm))
+  #  stop2("Empty PM data")
   
-  if(!length(am))
-    stop2("Empty AM data")
+  #if(!length(am))
+  #  stop2("Empty AM data")
   
   # Enforce lists
   if(is.singleton(pm)) 
@@ -31,7 +31,7 @@ dviData = function(pm, am, missing) {
   # Ensure `pm` is named
   names(pm) = unlist(labels(pm))
   
-  if(!(is.ped(am) || is.pedList(am)))
+  if(!(length(am) == 0 || is.ped(am) || is.pedList(am)))
     stop2("Argument `am` must be a `ped` object or a list of such")
   
   if(is.null(missing))
@@ -41,7 +41,7 @@ dviData = function(pm, am, missing) {
     stop2("Missing person not found in AM data: ", setdiff(missing, unlist(labels(am))))
   
   structure(list(pm = pm, am = am, missing = missing), 
-                  class = "dviData")
+                 class = "dviData")
 }
 
 
@@ -53,7 +53,7 @@ print.dviData = function(x, ..., heading = "DVI dataset:", printMax = 10) {
   missing = dvi$missing
   
   vics = names(pm)
-  refs = typedMembers(am)
+  refs = if(length(am)) typedMembers(am) else NULL
   nam = length(am)
   
   message(heading)

--- a/R/jointDVI.R
+++ b/R/jointDVI.R
@@ -144,6 +144,11 @@ jointDVI = function(dvi, pairings = NULL, ignoreSex = FALSE, assignments = NULL,
     # Expand pairings to assignment data frame
     assignments = expand.grid.nodup(pairings, max = maxAssign)
   }
+  else {
+    if(!setequal(names(assignments), origVics))
+      stop2("Names of `assignments` do not match `pm` names")
+    assignments = assignments[origVics]
+  }
   
   nAss = nrow(assignments)
   if(nAss == 0)
@@ -152,7 +157,7 @@ jointDVI = function(dvi, pairings = NULL, ignoreSex = FALSE, assignments = NULL,
     message("\nAssignments to consider in the joint analysis: ", nAss, "\n")
   
   # Convert to list; more handy below
-  assignmentList = lapply(1:nAss, function(i) as.character(assignments[i, origVics]))
+  assignmentList = lapply(1:nAss, function(i) as.character(assignments[i, ]))
   
   # Initial loglikelihoods
   logliks.PM = vapply(pm, loglikTotal, FUN.VALUE = 1)
@@ -191,7 +196,8 @@ jointDVI = function(dvi, pairings = NULL, ignoreSex = FALSE, assignments = NULL,
   # Add undisputed matches
   if(length(undisp)) {
     # Add ID columns
-    for(v in names(undisp)) assignments[[v]] = undisp[[v]]$match
+    for(v in names(undisp)) 
+      assignments[[v]] = undisp[[v]]$match
     
     # Fix ordering
     assignments = assignments[origVics]

--- a/R/jointDVI.R
+++ b/R/jointDVI.R
@@ -152,7 +152,7 @@ jointDVI = function(dvi, pairings = NULL, ignoreSex = FALSE, assignments = NULL,
     message("\nAssignments to consider in the joint analysis: ", nAss, "\n")
   
   # Convert to list; more handy below
-  assignmentList = lapply(1:nAss, function(i) as.character(assignments[i, ]))
+  assignmentList = lapply(1:nAss, function(i) as.character(assignments[i, origVics]))
   
   # Initial loglikelihoods
   logliks.PM = vapply(pm, loglikTotal, FUN.VALUE = 1)
@@ -161,7 +161,6 @@ jointDVI = function(dvi, pairings = NULL, ignoreSex = FALSE, assignments = NULL,
   loglik0 = sum(logliks.PM) + sum(logliks.AM)
   if(loglik0 == -Inf)
     stop2("Impossible initial data: AM component ", which(logliks.AM == -Inf))
-  
   
   # Parallelise
   if(numCores > 1) {


### PR DESCRIPTION
Intends to fix #48 . 

This now gives the correct output, I believe, but more testing would be good.

``` r
library(dvir, quietly = T)

jointDVI(example2, threshold = 1, verbose = F)
#>   V1 V2 V3   loglik  LR posterior
#> 1 M1 M2 M3 -16.1181 250         1
```
